### PR TITLE
Security: Fix estree-util-value-to-estree prototype pollution (CVE-2025-32014)

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -22,35 +22,36 @@
     "@remix-run/node": "^2.17.0",
     "@remix-run/react": "^2.17.0",
     "@remix-run/serve": "^2.17.0",
-    "isbot": "^4.1.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "isbot": "^4.4.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.17.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
-    "@types/react": "^18.2.20",
-    "@types/react-dom": "^18.2.7",
+    "@types/react": "^18.3.23",
+    "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^8.39.1",
     "@typescript-eslint/parser": "^8.39.1",
     "@vitejs/plugin-react": "^5.0.1",
     "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^8.38.0",
-    "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-import": "^2.28.1",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-react": "^7.33.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint": "^8.57.1",
+    "eslint-import-resolver-typescript": "^3.10.1",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "jsdom": "^26.1.0",
     "react-router-dom": "^7.8.0",
-    "typescript": "^5.1.6",
+    "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"
   },
   "pnpm": {
     "overrides": {
-      "esbuild": "^0.25.0"
+      "esbuild": "^0.25.0",
+      "estree-util-value-to-estree": "^3.3.3"
     }
   },
   "engines": {

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: ^0.25.0
+  estree-util-value-to-estree: ^3.3.3
 
 dependencies:
   '@fontsource/delius':
@@ -24,13 +25,13 @@ dependencies:
     specifier: ^2.17.0
     version: 2.17.0(typescript@5.8.3)
   isbot:
-    specifier: ^4.1.0
+    specifier: ^4.4.0
     version: 4.4.0
   react:
-    specifier: ^18.2.0
+    specifier: ^18.3.1
     version: 18.3.1
   react-dom:
-    specifier: ^18.2.0
+    specifier: ^18.3.1
     version: 18.3.1(react@18.3.1)
 
 devDependencies:
@@ -44,10 +45,10 @@ devDependencies:
     specifier: ^16.3.0
     version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7)(@types/react@18.3.23)(react-dom@18.3.1)(react@18.3.1)
   '@types/react':
-    specifier: ^18.2.20
+    specifier: ^18.3.23
     version: 18.3.23
   '@types/react-dom':
-    specifier: ^18.2.7
+    specifier: ^18.3.7
     version: 18.3.7(@types/react@18.3.23)
   '@typescript-eslint/eslint-plugin':
     specifier: ^8.39.1
@@ -62,22 +63,22 @@ devDependencies:
     specifier: ^3.2.4
     version: 3.2.4(vitest@3.2.4)
   eslint:
-    specifier: ^8.38.0
+    specifier: ^8.57.1
     version: 8.57.1
   eslint-import-resolver-typescript:
-    specifier: ^3.6.1
+    specifier: ^3.10.1
     version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
   eslint-plugin-import:
-    specifier: ^2.28.1
+    specifier: ^2.32.0
     version: 2.32.0(@typescript-eslint/parser@8.39.1)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
   eslint-plugin-jsx-a11y:
-    specifier: ^6.7.1
+    specifier: ^6.10.2
     version: 6.10.2(eslint@8.57.1)
   eslint-plugin-react:
-    specifier: ^7.33.2
+    specifier: ^7.37.5
     version: 7.37.5(eslint@8.57.1)
   eslint-plugin-react-hooks:
-    specifier: ^4.6.0
+    specifier: ^4.6.2
     version: 4.6.2(eslint@8.57.1)
   jsdom:
     specifier: ^26.1.0
@@ -86,7 +87,7 @@ devDependencies:
     specifier: ^7.8.0
     version: 7.8.0(react-dom@18.3.1)(react@18.3.1)
   typescript:
-    specifier: ^5.1.6
+    specifier: ^5.8.3
     version: 5.8.3
   vite:
     specifier: ^6.3.5
@@ -3342,11 +3343,10 @@ packages:
       source-map: 0.7.6
     dev: true
 
-  /estree-util-value-to-estree@1.3.0:
-    resolution: {integrity: sha512-Y+ughcF9jSUJvncXwqRageavjrNPAI+1M/L3BI3PyLp1nmgYTGUXU6t5z1Y7OWuThoDdhPME07bQU+d5LxdJqw==}
-    engines: {node: '>=12.0.0'}
+  /estree-util-value-to-estree@3.4.0:
+    resolution: {integrity: sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==}
     dependencies:
-      is-plain-obj: 3.0.0
+      '@types/estree': 1.0.8
     dev: true
 
   /estree-util-visit@1.2.1:
@@ -4141,11 +4141,6 @@ packages:
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
-    dev: true
-
-  /is-plain-obj@3.0.0:
-    resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
-    engines: {node: '>=10'}
     dev: true
 
   /is-plain-obj@4.1.0:
@@ -5901,7 +5896,7 @@ packages:
     engines: {node: '>=12.2.0'}
     dependencies:
       estree-util-is-identifier-name: 1.1.0
-      estree-util-value-to-estree: 1.3.0
+      estree-util-value-to-estree: 3.4.0
       js-yaml: 4.1.0
       toml: 3.0.0
     dev: true


### PR DESCRIPTION
## Summary
- Fixed prototype pollution vulnerability in estree-util-value-to-estree (CVE-2025-32014)
- Updated from vulnerable version 1.3.0 to secure version 3.4.0 using pnpm overrides
- Verified all quality checks pass (TypeScript, linting, tests, build)

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Test suite passes (36/36 tests)
- [x] Website build process completes successfully
- [x] Security vulnerability resolved (version 3.4.0 > required 3.3.3)

Close #48